### PR TITLE
Enable live theme editing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "command": "npm",
+  "command": "npx",
   "isShellCommand": true,
   "showOutput": "always",
   "suppressTaskName": true,
@@ -8,7 +8,7 @@
     {
       "isBuildCommand": true,
       "taskName": "build",
-      "args": ["start"]
+      "args": ["gulp"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ npm install
 
 Make your changes to the colors in index.ts and hit F5 to build the theme and launch the a new VS Code window with your theme available in the command palette (`ctrl`/`cmd+shift+p` > "Color Theme").
 
+## Live theme editing
+
+VS Code v1.30 and newer support live theme editing. Run
+
+```js
+npm start
+```
+
+to launch a VS Code window with your theme available. If you make changes to index.ts and save, [Gulp](https://gulpjs.com/) will automatically re-compile the theme and you will see your changes reflected in VS Code in seconds.
+
 ## Publishing
 
 When you're ready to publish your theme just fill out the `"name"`, `"displayName", `"publisher"` and `"description"` values in the package.json and [publish it like any other extension](https://code.visualstudio.com/docs/extensions/publish-extension).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,20 @@
+var gulp = require('gulp');
+var ts = require('gulp-typescript');
+var spawnSync = require('child_process').spawnSync;
+var through = require('through2');
+
+function build() {
+    return gulp.src('*.ts')
+        .pipe(ts())
+        .pipe(gulp.dest('.'))
+        .pipe(through.obj(function (file, encoding, callback) {
+            spawnSync('node', [ file.path ]);
+            callback(null, file);
+        }));
+}
+
+gulp.task(build);
+gulp.task('default', gulp.series('build'));
+gulp.task('watch', gulp.series('build', function() {
+    gulp.watch('*.ts', gulp.series('build'));
+}));

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "prestart": "tsc index.ts",
-    "start": "node index.js"
+    "start": "code . --extensionDevelopmentPath=\"$(pwd)\" && npx gulp watch"
   },
   "engines": {
     "vscode": "^1.11.0"
@@ -26,6 +25,10 @@
   },
   "devDependencies": {
     "@types/node": "^7.0.10",
+    "child_process": "^1.0.2",
+    "gulp": "^4.0.2",
+    "gulp-typescript": "^5.0.1",
+    "through2": "^3.0.1",
     "typescript": "^2.2.1",
     "vscode-theme-generator": "*"
   }


### PR DESCRIPTION
VS Code version 1.30 and newer support live theme editing. `npm start` will open an extension-development-host window and simultaneously run `gulp watch` to automatically re-compile the theme whenever index.ts is changed.

The old behavior of opening VS Code and pressing F5 to launch a separate extension-development-host window, without `gulp watch`, will still work.

No worries if you aren't interested, but I thought it was a cool idea :smiley: